### PR TITLE
[proto-defitions - Part 2] Deleting Table. Our table based types are CodeBlock, InfoBox, and Survey (not included yet).

### DIFF
--- a/third_party/tutorial.proto
+++ b/third_party/tutorial.proto
@@ -45,7 +45,6 @@ message BlockContent {
     Image image = 2;
     InfoBox info_box = 3;
     CodeBlock code_block = 4;
-    Table table = 6;
   }
 };
 
@@ -103,16 +102,4 @@ message List {
     UNORDERED = 2;
   }
   ListVariety list_variety = 2;
-};
-
-message Table {
-  repeated TableRow table_rows = 1;
-};
-
-message TableRow {
-  repeated TableCell table_cells = 1;
-};
-
-message TableCell {
-  repeated InlineContent inline_contents = 1;
 };


### PR DESCRIPTION
Deleting 'Table' Type as it's unused.

`CodeBlock`s, `InfoBox`es, and `Survey`s are the only elements that use "Table" as formatting in GDocs, but this format does not carry over to Markdown. Deleting to have a cleaner 1=>1 mapping of Types. 

Ideally, `Step` contents will be `repeated BlockContent`, and `BlockContent` will have all possible types that require special processing - meaning they are standalone `Step` elements - without further sub-type chaining.

In a Future PR, `Surveys` will be introduced.